### PR TITLE
Fikset visning av feilmelding fra backend også i Start

### DIFF
--- a/Workshop_1/Start/AzureWorkshop/AzureWorkshopApp/scripts/image-loading.ts
+++ b/Workshop_1/Start/AzureWorkshop/AzureWorkshopApp/scripts/image-loading.ts
@@ -11,7 +11,7 @@ const fetchImageLinks = () => {
             var errorContainer = document.getElementById("errors");
             var error = await response.json();
             var paragraph = document.createElement("p");
-            paragraph.appendChild(document.createTextNode(error ? error : response.status));
+            paragraph.appendChild(document.createTextNode(error ? JSON.stringify(error) : response.status.toString()));
             errorContainer.appendChild(paragraph);
             return;
         } else {


### PR DESCRIPTION
I eksisterende ble "[Object object]" vist når man fikk et objekt fra backend i stedet for selve feilen.